### PR TITLE
fix utc date

### DIFF
--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -106,7 +106,7 @@
     is parseable by Date.parse
     **/
     function parseSingleDate(dateStr){
-        if(isValidDateObj(dateStr)) return dateStr;
+        if(isValidDateObj(dateStr)) return toUTCDate(dateStr);
 
         // cross-browser check for ISO format that is not
         // supported by Date.parse without implicit time zone


### PR DESCRIPTION
There is no datepicker in brick project, and this one has bug when working with x-calendar from brick - when I click on date, previous date is selected.
I can publish test page if you want
